### PR TITLE
fix modal-content corners

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,8 @@
 .modal-content
 {
   border-color: #b7b7b7;
+  box-shadow: none !important;
+  -webkit-box-shadow: none !important;
 }
 
 .panel-group .panel+.panel


### PR DESCRIPTION
Fix .modal-content corners that look like this:
![Capture d’écran de 2020-04-20 14-43-43](https://user-images.githubusercontent.com/130780/79753495-4ea24d00-8316-11ea-8712-cbfbefd302d8.png)

instead of looking like this:
![Capture d’écran de 2020-04-20 14-52-21](https://user-images.githubusercontent.com/130780/79753653-8f01cb00-8316-11ea-982e-b5a37a656bbb.png)

